### PR TITLE
Handle HTTP error codes properly

### DIFF
--- a/src/lib/http-assert.js
+++ b/src/lib/http-assert.js
@@ -1,0 +1,6 @@
+export default function assertResponseOK(response) {
+  if (!response.ok) {
+      throw Error(response.statusText);
+  }
+  return response;
+}

--- a/src/reducers/dashboard/index.js
+++ b/src/reducers/dashboard/index.js
@@ -2,6 +2,7 @@ import { curry, compose, filter, reduce, map, indexBy, prop } from 'ramda';
 import { action } from 'types/common';
 import apiPath from 'lib/api-path';
 import requestJson from 'lib/request-json';
+import assertResponseOK from 'lib/http-assert';
 import { LOCATION_CHANGED } from 'redux-little-router';
 import { isRoute, dashboard as dashboardRoute } from 'lib/routes';
 import { serverToUser } from 'types/user';
@@ -51,9 +52,15 @@ export function fetchDashboard(dispatch) {
 }
 
 function dashboardRequest(dispatch) {
-  return fetch(`${apiPath}/sessions`)
+  return fetch(`${apiPath}/sessions`, {
+      mode: 'cors',
+      credentials: 'include',
+      headers: new Headers({'Accept': 'application/json'})
+    })
+    .then(assertResponseOK)
     .then(requestJson)
-    .then(compose(dispatch, action('dashboard/load-sessions'), indexBy(prop('id')), map(toDashboardSessionInfo)));
+    .then(compose(dispatch, action('dashboard/load-sessions'), indexBy(prop('id')), map(toDashboardSessionInfo)))
+    .catch(() => {});
 }
 
 function toDashboardSessionInfo({ session, answerer, questioners, questions }) {

--- a/src/reducers/session/index.js
+++ b/src/reducers/session/index.js
@@ -2,6 +2,7 @@ import { action } from 'types/common';
 import { compose, prop, curry, indexBy, map, isNil } from 'ramda';
 import { apiPath, wsPath } from 'lib/api-path';
 import requestJson from 'lib/request-json';
+import assertResponseOK from 'lib/http-assert';
 import { push, replace, LOCATION_CHANGED } from 'redux-little-router';
 import { session as sessionRoute } from 'lib/routes';
 
@@ -87,10 +88,12 @@ const joinRequest = (sessionId) => {
 
 const joinAndFetchSession = curry((sessionId, dispatch) => (
   joinRequest(sessionId)
+    .then(assertResponseOK)
     .then(requestJson)
     .then(() => {
       dispatch(push(sessionRoute(sessionId)));
     })
+    .catch(() => {})
 ));
 
 const openSessionSocket = curry((sessionId, dispatch) => {
@@ -185,10 +188,12 @@ const createSessionRequest = (topic) => (
 
 const createAndJoinSession = curry(({ topic }, dispatch) => (
   createSessionRequest(topic)
+    .then(assertResponseOK)
     .then(requestJson)
     .then((a) => {
       dispatch(replace(sessionRoute(a.sessionId)));
     })
+    .catch(() => {})
 ));
 
 export default session;

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -1,5 +1,6 @@
 import apiPath from 'lib/api-path';
 import requestJson from 'lib/request-json';
+import assertResponseOK from 'lib/http-assert';
 import { curry, compose, always } from 'ramda';
 import { action } from 'types/common';
 import { dashboard } from 'lib/routes';
@@ -55,7 +56,8 @@ const signInRequest = curry((name, password, dispatch) => {
       loginPassword: password
     })
   }).then(requestJson)
-    .then(compose(dispatch, action('user/loaded'), serverToUser));
+    .then(compose(dispatch, action('user/loaded'), serverToUser))
+    .catch(() => {});
 });
 
 export const signUp = action('user/sign_up');
@@ -69,15 +71,18 @@ const signUpRequest = curry((name, password, dispatch) => {
       userName: name,
       userPassword: password
     })
-  }).then(requestJson)
-    .then(compose(dispatch, action('user/loaded'), serverToUser));
+  }).then(assertResponseOK)
+    .then(requestJson)
+    .then(compose(dispatch, action('user/loaded'), serverToUser))
+    .catch(() => {});
 });
 
 const meRequest = (dispatch) => {
   return fetch(`${apiPath}/users/me`, {
     credentials: 'include',
     headers: new Headers({ 'Accept': 'application/json' })
-  }).then(requestJson)
+  }).then(assertResponseOK)
+    .then(requestJson)
     .then(compose(dispatch, action('user/loaded'), serverToUser))
     .catch(compose(dispatch, action('user/loaded'), always(null)));
 };


### PR DESCRIPTION
Previously this expected empty JSON responses when errors occurred and
ignored the HTTP status codes.