### PR TITLE
Default to empty arrays

### DIFF
--- a/src/components/dashboard/index.jsx
+++ b/src/components/dashboard/index.jsx
@@ -57,9 +57,13 @@ const partitionSessions = (sessions, user) => {
       otherSessions: values(sessions)
     }
   }
-  const answererSessions = user.answererSessions.map((id) => sessions[id]);
-  const questionerSessions = user.questionerSessions.map((id) => sessions[id]);
-  const userSessionIds = concat(user.answererSessions, user.questionerSessions);
+
+  const userAnswererSessions = user.answererSessions || []
+  const userQuestionerSessions = user.questionerSessions || []
+
+  const answererSessions = userAnswererSessions.map((id) => sessions[id]);
+  const questionerSessions = userQuestionerSessions.map((id) => sessions[id]);
+  const userSessionIds = concat(userAnswererSessions, userQuestionerSessions);
   const otherSessions = reject((s) => contains(s.id, userSessionIds), values(sessions));
 
   return {


### PR DESCRIPTION
I couldn't track down the source of this problem, but sometimes
this code is reached where `user.answererSessions` and
`user.questionerSessions` are undefined. They should probably default
and/or be properly set to empty arrays.

This patch is a work-around, but I am not sure where this should
be fixed proper.